### PR TITLE
fix: consistent device selection

### DIFF
--- a/circuit_tracer/attribution.py
+++ b/circuit_tracer/attribution.py
@@ -36,6 +36,7 @@ from transformer_lens.hook_points import HookPoint
 from circuit_tracer.graph import Graph
 from circuit_tracer.replacement_model import ReplacementModel
 from circuit_tracer.utils.disk_offload import offload_modules
+from circuit_tracer.utils.device import get_default_device
 
 
 class AttributionContext:
@@ -320,7 +321,7 @@ def select_encoder_rows(
 
 
 def compute_partial_influences(edge_matrix, logit_p, row_to_node_index, max_iter=128, device=None):
-    device = device or torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    device = device or get_default_device()
 
     normalized_matrix = torch.empty_like(edge_matrix, device=device).copy_(edge_matrix)
     normalized_matrix = normalized_matrix.abs_()

--- a/circuit_tracer/replacement_model.py
+++ b/circuit_tracer/replacement_model.py
@@ -9,6 +9,7 @@ from transformer_lens import HookedTransformer, HookedTransformerConfig
 from transformer_lens.hook_points import HookPoint
 
 from circuit_tracer.transcoder import SingleLayerTranscoder, load_transcoder_set
+from circuit_tracer.utils.device import get_default_device
 
 
 class ReplacementMLP(nn.Module):
@@ -126,7 +127,7 @@ class ReplacementModel(HookedTransformer):
         cls,
         model_name: str,
         transcoder_set: str,
-        device: Optional[torch.device] = torch.device("cuda"),
+        device: Optional[torch.device] = None,
         dtype: Optional[torch.dtype] = torch.float32,
         **kwargs,
     ) -> "ReplacementModel":
@@ -138,11 +139,14 @@ class ReplacementModel(HookedTransformer):
             transcoder_set (str): Either a predefined transcoder set name, or a config file
                 defining where to load them from
             device (torch.device, Optional): the device onto which to load the transcoders
-                and HookedTransformer.
+                and HookedTransformer. Defaults to None (auto-detect).
 
         Returns:
             ReplacementModel: The loaded ReplacementModel
         """
+        if device is None:
+            device = get_default_device()
+            
         transcoders, feature_input_hook, feature_output_hook, scan = load_transcoder_set(
             transcoder_set, device=device, dtype=dtype
         )

--- a/circuit_tracer/utils/__init__.py
+++ b/circuit_tracer/utils/__init__.py
@@ -1,3 +1,4 @@
 from circuit_tracer.utils.create_graph_files import create_graph_files
+from circuit_tracer.utils.device import get_default_device
 
-__all__ = ["create_graph_files"]
+__all__ = ["create_graph_files", "get_default_device"]

--- a/circuit_tracer/utils/create_graph_files.py
+++ b/circuit_tracer/utils/create_graph_files.py
@@ -9,6 +9,7 @@ from transformers import AutoTokenizer
 from circuit_tracer.frontend.graph_models import Metadata, Model, Node, QParams
 from circuit_tracer.frontend.utils import add_graph_metadata, process_token
 from circuit_tracer.graph import Graph, prune_graph
+from circuit_tracer.utils.device import get_default_device
 
 logger = logging.getLogger(__name__)
 
@@ -181,7 +182,7 @@ def create_graph_files(
             )
         scan = graph.scan
 
-    device = "cuda" if torch.cuda.is_available() else "cpu"
+    device = get_default_device()
     graph.to(device)
     node_mask, edge_mask, cumulative_scores = (
         el.cpu() for el in prune_graph(graph, node_threshold, edge_threshold)

--- a/circuit_tracer/utils/device.py
+++ b/circuit_tracer/utils/device.py
@@ -1,0 +1,13 @@
+# circuit_tracer/utils/device.py
+import torch
+
+def get_default_device() -> torch.device:
+    """Smart device detection - CUDA > MPS > CPU"""
+    if torch.cuda.is_available():
+        return torch.device("cuda")
+    elif torch.backends.mps.is_available():
+        # MPS is not supported for sparse tensors
+        #return torch.device("mps") 
+        return torch.device("cpu")
+    else:
+        return torch.device("cpu")

--- a/tests/test_attributions_gemma.py
+++ b/tests/test_attributions_gemma.py
@@ -12,6 +12,7 @@ from circuit_tracer.graph import Graph
 from circuit_tracer.replacement_model import ReplacementModel
 from circuit_tracer.transcoder import SingleLayerTranscoder
 from circuit_tracer.transcoder.activation_functions import JumpReLU
+from circuit_tracer.utils.device import get_default_device
 
 
 def verify_token_and_error_edges(
@@ -24,9 +25,10 @@ def verify_token_and_error_edges(
     logit_rtol=1e-3,
 ):
     s = graph.input_tokens
-    adjacency_matrix = graph.adjacency_matrix.cuda()
-    active_features = graph.active_features.cuda()
-    logit_tokens = graph.logit_tokens.cuda()
+    device = get_default_device()
+    adjacency_matrix = graph.adjacency_matrix.to(device)
+    active_features = graph.active_features.to(device)
+    logit_tokens = graph.logit_tokens.to(device)
     total_active_features = active_features.size(0)
     pos_start = 1 if delete_bos else 0
 
@@ -114,9 +116,10 @@ def verify_feature_edges(
     logit_rtol=1e-3,
 ):
     s = graph.input_tokens
-    adjacency_matrix = graph.adjacency_matrix.cuda()
-    active_features = graph.active_features.cuda()
-    logit_tokens = graph.logit_tokens.cuda()
+    device = get_default_device()
+    adjacency_matrix = graph.adjacency_matrix.to(device)
+    active_features = graph.active_features.to(device)
+    logit_tokens = graph.logit_tokens.to(device)
     total_active_features = active_features.size(0)
 
     logits, activation_cache = model.get_activations(s, apply_activation_function=False)
@@ -223,7 +226,7 @@ def verify_small_gemma_model(s: torch.Tensor):
         "attn_types": ["global", "local"],
         "init_mode": "gpt2",
         "normalization_type": "RMSPre",
-        "device": device(type="cuda"),
+        "device": get_default_device(),
         "n_devices": 1,
         "attention_dir": "causal",
         "attn_only": False,
@@ -317,7 +320,7 @@ def verify_large_gemma_model(s: torch.Tensor):
         ],
         "init_mode": "gpt2",
         "normalization_type": "RMSPre",
-        "device": device(type="cuda"),
+        "device": get_default_device(),
         "n_devices": 1,
         "attention_dir": "causal",
         "attn_only": False,

--- a/tests/test_attributions_llama.py
+++ b/tests/test_attributions_llama.py
@@ -11,6 +11,7 @@ from circuit_tracer.attribution import attribute
 from circuit_tracer.replacement_model import ReplacementModel
 from circuit_tracer.transcoder import SingleLayerTranscoder
 from circuit_tracer.transcoder.activation_functions import TopK
+from circuit_tracer.utils.device import get_default_device
 
 sys.path.append(os.path.dirname(__file__))
 from test_attributions_gemma import verify_feature_edges, verify_token_and_error_edges
@@ -65,7 +66,7 @@ def verify_small_llama_model(s: torch.Tensor):
         "attn_types": None,
         "init_mode": "gpt2",
         "normalization_type": "RMSPre",
-        "device": device(type="cuda"),
+        "device": get_default_device(),
         "n_devices": 1,
         "attention_dir": "causal",
         "attn_only": False,
@@ -144,7 +145,7 @@ def verify_large_llama_model(s: torch.Tensor):
         "attn_types": None,
         "init_mode": "gpt2",
         "normalization_type": "RMSPre",
-        "device": device(type="cuda"),
+        "device": get_default_device(),
         "n_devices": 1,
         "attention_dir": "causal",
         "attn_only": False,

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -4,6 +4,7 @@ from torch import device
 from transformer_lens import HookedTransformerConfig
 
 from circuit_tracer.graph import Graph, compute_edge_influence, compute_node_influence
+from circuit_tracer.utils.device import get_default_device
 
 
 def test_small_graph():
@@ -67,7 +68,7 @@ def test_small_graph():
         "attn_types": ["global", "local"],
         "init_mode": "gpt2",
         "normalization_type": "RMSPre",
-        "device": device(type="cuda"),
+        "device": get_default_device(),
         "n_devices": 1,
         "attention_dir": "causal",
         "attn_only": False,


### PR DESCRIPTION
This allows the code to run (albeit slowly) on MacOS without a CUDA device.

I also experimented with using MPS, and got further than indicated here. As noted in #1, there are issues with the SparseMPS backend, which is mostly not implemented. Sparse tensors are used for e.g. transcoder activations. I think it might not be terrible to do a workaround where MPS devices are used except for the sparse computations, as unlike with CUDA, the cost of shuttling tensors "between" devices on Apple Silicon is minimal (it's all unified memory). However I haven't actually got this working to be able to test it.

In the meantime, the entire codebase now has consistent device selection defaults and the notebooks will run on a Mac.