### PR TITLE
fix: intervention notebook example should ablate French, not Spanish

### DIFF
--- a/demos/intervention_demo.ipynb
+++ b/demos/intervention_demo.ipynb
@@ -761,7 +761,7 @@
     "sequence_length = len(model.tokenizer(s_spanish).input_ids)\n",
     "original_feature_pos = sequence_length - 1\n",
     "open_ended_slice = slice(original_feature_pos, None, None)\n",
-    "open_ended_es_fr_intervention_tuples = [(layer, open_ended_slice, feature_idx, 0.0) for (layer, _, feature_idx) in spanish_supernode_features] \n",
+    "open_ended_es_fr_intervention_tuples = [(layer, open_ended_slice, feature_idx, 0.0) for (layer, _, feature_idx) in french_supernode_features] \n",
     "open_ended_es_fr_intervention_tuples+= [(layer, open_ended_slice, feature_idx, 10*activations[layer, orig_pos, feature_idx]) for (layer, orig_pos, feature_idx) in spanish_supernode_features]"
    ]
   },


### PR DESCRIPTION
**Problem**
The last example of the demo intervention notebook is supposed to follow the pattern of the other examples by ablating French and steering toward Spanish. It currently ablates Spanish, then steers Spanish.

This isn't an urgent fix, mostly it's to avoid confusion from the reader. There's no significant impact on the steering outcome, since the steering Spanish overrides the ablation, and it isn't necessary to ablate French for it to produce a Spanish output.

**Fix**
In the last intervention notebook example, change the first `spanish_supernode_features` to `french_supernode_features`.

**Verification**
Ran the modified notebook and the output is the same.
