### PR TITLE
Docs/Demo: _get_feature_intervention_hooks is no longer directly used

### DIFF
--- a/demos/intervention_demo.ipynb
+++ b/demos/intervention_demo.ipynb
@@ -769,7 +769,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now, we just get the necessary hooks by calling `model._get_feature_intervention_hooks`, and use those hooks to generate! Make sure to set `use_past_kv_cache` to false, otherwise the model will attempt to generate using the KV cache + length=1 inputs; this is more efficient, but makes interventions hard. `do_sample` is off here for consistency, but you can turn it on as well."
+    "Now, we generate by calling `feature_intervention_generate`! Make sure to set `use_past_kv_cache` to false, otherwise the model will attempt to generate using the KV cache + length=1 inputs; this is more efficient, but makes interventions hard. `do_sample` is off here for consistency, but you can turn it on as well."
    ]
   },
   {


### PR DESCRIPTION
Since v0.2.0 `_get_feature_intervention_hooks` is no longer directly called (and behaves slightly differently than before). Instead, we call `feature_intervention_generate`. The demo notebook's code correctly does this, but the description is still the old one.

I wrote in a simple replacement description but feel free to change it (and any corresponding text afterward).