### PR TITLE
Don't replace newlines with return symbol in graph files

### DIFF
--- a/circuit_tracer/frontend/assets/attribution_graph/util-cg.js
+++ b/circuit_tracer/frontend/assets/attribution_graph/util-cg.js
@@ -183,6 +183,10 @@ window.utilCg = (function(){
     return {nodes, links}
   }
 
+  function replaceWhitespace(token) {
+    return token.replaceAll("\n", "⏎").replaceAll("\t", "→").replaceAll("\r", "↵")
+  }
+
   // Decorates and mutates data.json
   // - Adds pointers between node and links
   // - Deletes very common features
@@ -203,6 +207,9 @@ window.utilCg = (function(){
         visState.pinnedIds.includes(d.nodeId)
       )
     }
+
+    // update all prompt tokens to replace \n, \t, \r with ⏎, →, ↵
+    data.metadata.prompt_tokens = data.metadata.prompt_tokens.map(replaceWhitespace)
 
     nodes.forEach((d, i) => {
       // To make hover state work across prompts, drop ctx from node id

--- a/circuit_tracer/utils/create_graph_files.py
+++ b/circuit_tracer/utils/create_graph_files.py
@@ -7,7 +7,7 @@ import torch
 from transformers import AutoTokenizer
 
 from circuit_tracer.frontend.graph_models import Metadata, Model, Node, QParams
-from circuit_tracer.frontend.utils import add_graph_metadata, process_token
+from circuit_tracer.frontend.utils import add_graph_metadata
 from circuit_tracer.graph import Graph, prune_graph
 
 logger = logging.getLogger(__name__)
@@ -56,7 +56,7 @@ def create_nodes(graph: Graph, node_mask, tokenizer, cumulative_scores):
             nodes[node_idx] = Node.logit_node(
                 pos=graph.n_pos - 1,
                 vocab_idx=graph.logit_tokens[pos],
-                token=process_token(tokenizer.decode(graph.logit_tokens[pos])),
+                token=tokenizer.decode(graph.logit_tokens[pos]),
                 target_logit=pos == 0,
                 token_prob=graph.logit_probabilities[pos].item(),
                 num_layers=layers,
@@ -118,7 +118,7 @@ def build_model(graph: Graph, used_nodes, used_edges, slug, scan, node_threshold
         slug=slug,
         scan=scan,
         transcoder_list=transcoder_list,
-        prompt_tokens=[process_token(tokenizer.decode(t)) for t in graph.input_tokens],
+        prompt_tokens=[tokenizer.decode(t) for t in graph.input_tokens],
         prompt=graph.input_string,
         node_threshold=node_threshold,
     )


### PR DESCRIPTION
**TLDR**
Graph **files** should not replace `\n` with ⏎, since the files are a 'source of truth', and other people use them as inputs for their workflows. This is a simple fix to remove that replacement. The graph **frontend** should do the replacements when displaying to the user.

**Issue**
I ran into this issue because we are using prompt_tokens for steering and I was confused why we were getting unexpected outputs. It turns out we were passing in the ⏎ symbol instead of `\n`.

In outputted graph json and the `graph-metadata.json`, newlines (`\n`) are replaced with `⏎`, `\t` replaced with `→`, `\n` replaced with `↵`. While the motivation for this is understandable (we want to visibly display the newline characters in the frontend), this makes the data in the graph files themselves unreliable/inaccurate for later usage. Eg the tokens are actually newlines, not the symbol `⏎` (which is a different token).

For example, in `graph-metadata.json`, we currently output this:
```
      "prompt_tokens": [
        "<bos>",
        "1",
        "\u23ce\u23ce",    <--- this should be "\n\n"
        "2"
      ],
      "prompt": "<bos>1\n\n2",
```
While `prompt` gives us the correct original `\n\n`, `prompt_tokens` gives us the token `\u23ce\u23ce`.

**Proposed Fix/PR**
The graph files themselves should use the original characters, that's what this PR does.
The replacement of `\n`, `\t`, and `\r` should occur on the frontend. I am opening a new PR to resolve that.

**Potential Workarounds**
Instead of changing this, workarounds are:
1) We use `prompt` field instead of `prompt_tokens`, then tokenize ourselves. Not ideal/intuitive since we are already given a `prompt_tokens` field, and potentially runs into stuff with BOS tokens.
2) We replace `⏎` back into `\n` when consuming `prompt_tokens`. Not ideal since it's possible that the token we want to use is actually `⏎`, and also we'd have to keep special casing this (error-prone).