### PR TITLE
GemmaScope Transcoder Bugfix

### DIFF
--- a/circuit_tracer/transcoder/single_layer_transcoder.py
+++ b/circuit_tracer/transcoder/single_layer_transcoder.py
@@ -369,12 +369,10 @@ def load_gemma_scope_transcoder(
     del param_dict["threshold"]
 
     # create the transcoders
-    # d_model = param_dict["W_enc"].shape[0]
-    # d_transcoder = param_dict["W_enc"].shape[1]
     d_transcoder, d_model = param_dict["W_enc"].shape
 
-    # dummy JumpReLU; will get loaded via load_state_dict
-    activation_function = JumpReLU(torch.tensor(0.0), 0.1)
+    # JumpReLU; will get loaded via load_state_dict
+    activation_function = JumpReLU(param_dict["activation_function.threshold"], 0.1)
     with torch.device("meta"):
         transcoder = SingleLayerTranscoder(d_model, d_transcoder, activation_function, layer)
     transcoder.load_state_dict(param_dict, assign=True)

--- a/demos/attribute_demo.ipynb
+++ b/demos/attribute_demo.ipynb
@@ -333,7 +333,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.11.11"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Previously, GemmaScope transcoders were being loaded with a scalar threshold parameter; however, this should have been a vector-valued threshold parameter. This PR fixes that.